### PR TITLE
usleep fix

### DIFF
--- a/source/unix/tuv_unix_port_system.c
+++ b/source/unix/tuv_unix_port_system.c
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#include <unistd.h> // usleep
+
 #include <uv.h>
 
 #include "uv__unix_platform.h"

--- a/test/test_timer.c
+++ b/test/test_timer.c
@@ -35,7 +35,6 @@
  */
 
 #include <string.h>
-#include <unistd.h> // usleep
 #include <uv.h>
 
 
@@ -342,7 +341,7 @@ TEST_IMPL(timer_run_once) {
   TUV_ASSERT(0 == uv_timer_start(&timer_handle, timer_run_once_timer_cb, 1, 0));
   // slow systems may have nano second resolution
   // give some time to sleep so that time tick is changed
-  uv_usleep(1000);
+  tuv_usleep(1000);
   TUV_ASSERT(0 == uv_run(uv_default_loop(), UV_RUN_ONCE));
   TUV_ASSERT(2 == timer_run_once_timer_cb_called);
 


### PR DESCRIPTION
* test_timer.c used non-existing function uv_usleep
* tuv_unix_port_system.c needs unistd.h for usleep but test_timer.c doesn't anymore

fixes #16 