### PR TITLE
inline declaration removal

### DIFF
--- a/source/linux/uv_platform.h
+++ b/source/linux/uv_platform.h
@@ -99,7 +99,7 @@ uint64_t uv__hrtime(uv_clocktype_t type);
 #define uv__update_time(loop)                                                 \
   loop->time = uv__hrtime(UV_CLOCK_FAST) / 1000000
 
-inline uint64_t uv__time_precise();
+uint64_t uv__time_precise();
 
 
 //-----------------------------------------------------------------------------

--- a/source/mbed/uv_platform.h
+++ b/source/mbed/uv_platform.h
@@ -78,7 +78,7 @@ uint64_t uv__hrtime(uv_clocktype_t type);
 #define uv__update_time(loop)                                                 \
   loop->time = uv__hrtime(UV_CLOCK_FAST) / 1000000
 
-inline uint64_t uv__time_precise();
+uint64_t uv__time_precise();
 
 void tuv__time_init(void);
 

--- a/source/nuttx/uv_platform.h
+++ b/source/nuttx/uv_platform.h
@@ -106,7 +106,7 @@ uint64_t uv__hrtime();
 #define uv__update_time(loop)                                                 \
   loop->time = uv__hrtime() / 1000000
 
-inline uint64_t uv__time_precise();
+uint64_t uv__time_precise();
 
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
GCC 5 is more strict about inline semantics: inline declaration without definition emits warning during compilation and will also cause an undefined reference error during linking.

Thus, removing the inline specifier from the declarations of uv__time_precise().

fixes #18 

Notes:
* Works on linux, speculatively applying the inline specifier removal to other targets as well.
* Admittedly not sure why the inlines were there originally. The only headers that contain `inline` are the three `uv_platforms.h`s and only for uv__time_precise().
