### PR TITLE
add openwrt support

### DIFF
--- a/cmake/config/config_mips-openwrt.cmake
+++ b/cmake/config/config_mips-openwrt.cmake
@@ -1,0 +1,21 @@
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+set(CMAKE_SYSTEM_NAME Openwrt)
+set(CMAKE_SYSTEM_PROCESSOR mips)
+
+SET(CMAKE_C_COMPILER   mipsel-openwrt-linux-gcc)
+SET(CMAKE_CXX_COMPILER mipsel-openwrt-linux-g++)

--- a/cmake/option/option_mips-openwrt.cmake
+++ b/cmake/option/option_mips-openwrt.cmake
@@ -1,0 +1,39 @@
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# linux common
+include("cmake/option/option_unix_common.cmake")
+
+set(TUV_PLATFORM_PATH "linux")
+
+# linux specific source files
+set(LINUX_PATH "${SOURCE_ROOT}/${TUV_PLATFORM_PATH}")
+
+set(PLATFORM_SRCFILES ${PLATFORM_SRCFILES}
+                      "${LINUX_PATH}/uv_linux.c"
+                      "${LINUX_PATH}/uv_linux_loop.c"
+                      "${LINUX_PATH}/uv_linux_clock.c"
+                      "${LINUX_PATH}/uv_linux_io.c"
+                      "${LINUX_PATH}/uv_linux_syscall.c"
+                      "${LINUX_PATH}/uv_linux_thread.c"
+                      )
+
+set(PLATFORM_TESTFILES "${TEST_ROOT}/runner_linux.c"
+                       )
+
+set(TUV_LINK_LIBS "pthread")
+
+# mips-linux specific
+if(DEFINED TARGET_BOARD)
+endif()

--- a/source/unix/uv_unix_async.c
+++ b/source/unix/uv_unix_async.c
@@ -83,9 +83,12 @@ static int uv__async_eventfd() {
   if (no_eventfd2)
     goto skip_eventfd2;
 
-  fd = uv__eventfd2(0, UV__EFD_CLOEXEC | UV__EFD_NONBLOCK);
+  fd = uv__eventfd2(0, 0);
   if (fd != -1)
     return fd;
+
+  fcntl(fd, F_SETFL , UV__EFD_NONBLOCK);
+  fcntl(fd, F_SETFD , UV__EFD_CLOEXEC);
 
   if (errno != ENOSYS)
     return -errno;


### PR DESCRIPTION
add cmake files for openwrt,
and change in uv_unix_async.c, without this change, calling to uv__eventfd2 will return "Invalid argument" error on openwrt board.
I think it's  caused by non zero flags passed when make __NR_eventfd2 system call. 
Refer to http://linux.die.net/man/2/eventfd2, I find this "In Linux up to version 2.6.26, the flags argument is unused, and must be specified as zero", so I make change using fcntl to set the flags.