### PR TITLE
Bump minimum required cmake version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(libtuv)
 
 set(LIBTUV_VERSION_MAJOR 0)

--- a/cmake/apiemultest.cmake
+++ b/cmake/apiemultest.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(TUVTESTNAME "tuvtester")
 

--- a/cmake/libtuv.cmake
+++ b/cmake/libtuv.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # temporary block to make one file at a time for mbed
 if(${PLATFORM_NAME_L} STREQUAL "mbed")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # platform name in lower case
 string(TOLOWER ${CMAKE_SYSTEM_NAME} PLATFORM_NAME_L)

--- a/cmake/tuvtest.cmake
+++ b/cmake/tuvtest.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 
 set(TEST_PLATFORMFILES )


### PR DESCRIPTION
At least one feature, the SYSTEM argument of target_include_directories
needs 2.8.12.

libtuv-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu