### PR TITLE
Put quotes around `${}` variable expansions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,9 @@ set(LIBTUV_VERSION_MINOR 1)
 #
 include(cmake/options.cmake)
 include(cmake/libtuv.cmake)
-if (DEFINED BUILDTESTER AND ${BUILDTESTER} STREQUAL "yes")
+if (DEFINED BUILDTESTER AND "${BUILDTESTER}" STREQUAL "yes")
   include(cmake/tuvtest.cmake)
-elseif (DEFINED BUILDAPIEMULTESTER AND ${BUILDAPIEMULTESTER} STREQUAL "yes")
+elseif (DEFINED BUILDAPIEMULTESTER AND "${BUILDAPIEMULTESTER}" STREQUAL "yes")
   include(cmake/apiemultest.cmake)
 endif()
 


### PR DESCRIPTION
If `BUILDTESTER` and/or `BUILDAPIEMULTESTER` are not defined for
cmake on the command line, `${} STREQUAL ""` constructs fail as
left-hand side gets expanded to nothing. Putting quotes around the
expansions ensures that they get expanded to the empty string in
such cases.

libtuv-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu