### PR TITLE
Change board name for STM32F4-discovery to fix broken iotjs-nuttx build

### DIFF
--- a/Makefile.all
+++ b/Makefile.all
@@ -38,7 +38,7 @@ rpi2:
 
 
 stm32f4:
-	TUV_PLATFORM=arm-nuttx TUV_BOARD=stm32f4 \
+	TUV_PLATFORM=arm-nuttx TUV_BOARD=stm32f4dis \
 	 TUV_SYSTEMROOT=$(HARMONY)/nuttx/nuttx make
 
 

--- a/cmake/option/option_arm-nuttx.cmake
+++ b/cmake/option/option_arm-nuttx.cmake
@@ -38,7 +38,7 @@ set(PLATFORM_SRCFILES
 set(PLATFORM_TESTFILES "${TEST_ROOT}/runner_nuttx.c")
 
 if(DEFINED TARGET_BOARD)
-  if(${TARGET_BOARD} STREQUAL "stm32f4")
+  if(${TARGET_BOARD} STREQUAL "stm32f4dis")
     set(FLAGS_COMMON
           ${FLAGS_COMMON}
           "-mcpu=cortex-m4"


### PR DESCRIPTION
https://github.com/Samsung/iotjs/issues/373
Board name becomes `stm32f4dis` according to .build.default.config file in iotjs repo