### PR TITLE
Fix segmentation fault in fs_stat (iotjs #323)

### DIFF
--- a/source/unix/uv_unix_fs.c
+++ b/source/unix/uv_unix_fs.c
@@ -77,9 +77,11 @@
 
 #define PATH                                                                  \
   do {                                                                        \
-    (req)->path = strdup(path);                                               \
-    if ((req)->path == NULL)                                                  \
-      return -ENOMEM;                                                         \
+    if (path != NULL) {                                                       \
+      (req)->path = strdup(path);                                             \
+      if ((req)->path == NULL)                                                \
+        return -ENOMEM;                                                       \
+    }                                                                         \
   }                                                                           \
   while (0)
 


### PR DESCRIPTION
It fixes #323 issue in Samsung/iotjs.
uv_fs_stat uses macro PATH. In PATH macro, path is duplicated using
strdup without null-checking. I inserted null check before strdup.

libtuv-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com