### PR TITLE
Bug fix for IPv6 style address.

### DIFF
--- a/source/unix/uv_unix_getaddrinfo.c
+++ b/source/unix/uv_unix_getaddrinfo.c
@@ -118,6 +118,9 @@ static void uv__getaddrinfo_work(struct uv__work* w) {
 #if defined(__NUTTX__)
   err = 0;
 #else
+  /* Only IPv4 is supported now. (Not support IPv6.)*/
+  if (req->hints)
+    req->hints->ai_family = AF_INET;
   err = getaddrinfo(req->hostname, req->service, req->hints, &req->addrinfo);
 #endif
   req->retcode = uv__getaddrinfo_translate_error(err);


### PR DESCRIPTION
libtuv is not supported IPv6 now.
However, IPv6 style address is entered, program is not finished.

This commit is related with https://github.com/Samsung/iotjs/issues/397.

libtuv-DCO-1.0-Signed-off-by: Jaechul Yang jc08.yang@samsung.com