### PR TITLE
Refactor TCP module

### DIFF
--- a/cmake/libtuv.cmake
+++ b/cmake/libtuv.cmake
@@ -47,6 +47,7 @@ else()
         "${SOURCE_ROOT}/uv_dir.c"
         "${SOURCE_ROOT}/uv_inet.c"
         "${SOURCE_ROOT}/uv_udp.c"
+        "${SOURCE_ROOT}/uv_tcp.c"
         )
 endif()
 

--- a/include/uv__tcp.h
+++ b/include/uv__tcp.h
@@ -83,15 +83,10 @@ int uv_tcp_connect(uv_connect_t* req, uv_tcp_t* handle,
 
 int uv_tcp_listen(uv_tcp_t* tcp, int backlog, uv_connection_cb cb);
 
-int uv__tcp_bind(uv_tcp_t* tcp, const struct sockaddr* addr,
-                 unsigned int addrlen, unsigned int flags);
-int uv__tcp_connect(uv_connect_t* req, uv_tcp_t* handle,
-                   const struct sockaddr* addr, unsigned int addrlen,
-                   uv_connect_cb cb);
-
-int uv__tcp_nodelay(int fd, int on);
-int uv__tcp_keepalive(int fd, int on, unsigned int delay);
-void uv__tcp_close(uv_tcp_t* handle);
+int uv_tcp_getsockname(const uv_tcp_t* handle, struct sockaddr* name,
+                       int* namelen);
+int uv_tcp_getpeername(const uv_tcp_t* handle, struct sockaddr* name,
+                       int* namelen);
 
 
 

--- a/source/unix/uv_unix_tcp.c
+++ b/source/unix/uv_unix_tcp.c
@@ -225,57 +225,6 @@ int uv_tcp_init(uv_loop_t* loop, uv_tcp_t* tcp) {
 }
 
 
-int uv_tcp_bind(uv_tcp_t* handle,
-                const struct sockaddr* addr,
-                unsigned int flags) {
-  unsigned int addrlen;
-
-  if (handle->type != UV_TCP) {
-    return UV_EINVAL;
-  }
-
-  if (addr->sa_family == AF_INET) {
-    addrlen = sizeof(struct sockaddr_in);
-  }
-/*
-  else if (addr->sa_family == AF_INET6) {
-    addrlen = sizeof(struct sockaddr_in6);
-  }
-*/
-  else {
-    return UV_EINVAL;
-  }
-
-  return uv__tcp_bind(handle, addr, addrlen, flags);
-}
-
-
-int uv_tcp_connect(uv_connect_t* req,
-                   uv_tcp_t* handle,
-                   const struct sockaddr* addr,
-                   uv_connect_cb cb) {
-  unsigned int addrlen;
-
-  if (handle->type != UV_TCP) {
-    return UV_EINVAL;
-  }
-
-  if (addr->sa_family == AF_INET) {
-    addrlen = sizeof(struct sockaddr_in);
-  }
-/*
-  else if (addr->sa_family == AF_INET6) {
-    addrlen = sizeof(struct sockaddr_in6);
-  }
-*/
-  else {
-    return UV_EINVAL;
-  }
-
-  return uv__tcp_connect(req, handle, addr, addrlen, cb);
-}
-
-
 int uv_tcp_open(uv_tcp_t* handle, uv_os_sock_t sock) {
   int err;
 

--- a/source/uv_tcp.c
+++ b/source/uv_tcp.c
@@ -1,0 +1,87 @@
+/* Copyright 2016 Samsung Electronics Co., Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Copyright Joyent, Inc. and other Node contributors. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include "uv.h"
+
+
+int uv_tcp_bind(uv_tcp_t* handle, const struct sockaddr* addr,
+                unsigned int flags) {
+  unsigned int addrlen;
+
+  if (handle->type != UV_TCP) {
+    return UV_EINVAL;
+  }
+
+  if (addr->sa_family == AF_INET) {
+    addrlen = sizeof(struct sockaddr_in);
+  }
+/*
+  else if (addr->sa_family == AF_INET6) {
+    addrlen = sizeof(struct sockaddr_in6);
+  }
+*/
+  else {
+    return UV_EINVAL;
+  }
+
+  return uv__tcp_bind(handle, addr, addrlen, flags);
+}
+
+
+int uv_tcp_connect(uv_connect_t* req, uv_tcp_t* handle,
+                   const struct sockaddr* addr,
+                   uv_connect_cb cb) {
+  unsigned int addrlen;
+
+  if (handle->type != UV_TCP) {
+    return UV_EINVAL;
+  }
+
+  if (addr->sa_family == AF_INET) {
+    addrlen = sizeof(struct sockaddr_in);
+  }
+/*
+  else if (addr->sa_family == AF_INET6) {
+    addrlen = sizeof(struct sockaddr_in6);
+  }
+*/
+  else {
+    return UV_EINVAL;
+  }
+
+  return uv__tcp_connect(req, handle, addr, addrlen, cb);
+}
+


### PR DESCRIPTION
* Move common functions to `uv_tcp.c`
* Organize `uv__tcp.h` and Make `uv_tcp_get[sock|peer]name` public

libtuv-DCO-1.0-Signed-off-by: wonyong.kim wonyong.kim@samsung.com