### PR TITLE
Specify project language as C.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: cpp
+language: c
 
 os: linux
 dist: trusty

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 2.8.12)
-project(libtuv)
+project(libtuv C)
 
 set(LIBTUV_VERSION_MAJOR 0)
 set(LIBTUV_VERSION_MINOR 1)


### PR DESCRIPTION
cmake try to validate C++ compiler. However, we don't need
the check anymore since we had migrated from C++ to C.
Also, I set travis language as C.

libtuv-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com