### PR TITLE
Fix file system request init and cleanup

### DIFF
--- a/test/raw/test_tcp_open_raw.c
+++ b/test/raw/test_tcp_open_raw.c
@@ -75,7 +75,7 @@ static uv_write_t write_req;
 
 
 static void startup(void) {
-  tuv_usleep(1000);
+  uv_sleep(1);
 }
 
 

--- a/test/raw/test_timer_raw_run_once.c
+++ b/test/raw/test_timer_raw_run_once.c
@@ -74,7 +74,7 @@ TEST_IMPL(timer_run_once) {
                                 timer_run_once_timer_cb, 1, 0));
   // slow systems may have nano second resolution
   // give some time to sleep so that time tick is changed
-  tuv_usleep(1000);
+  uv_sleep(1);
   TUV_ASSERT(0 == uv_run(param->loop, UV_RUN_ONCE));
   TUV_ASSERT(2 == timer_run_once_timer_cb_called);
 


### PR DESCRIPTION
We did not use fs init and cleanup as uv 1.10.1 is.
The code has shown smaller footprint.
But it introduced memory leak problem when it is not
managed carefully. Thus we want to use uv's as it is.

In addition, I changed tuv_usleep to uv_sleep in test/raw/*.

libtuv-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com