### PR TITLE
Fix build break occuring in use of uv_poll_init

### DIFF
--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -467,7 +467,6 @@ int uv__close(int fd) {
     defined(__FreeBSD__) || \
     defined(__FreeBSD_kernel__) || \
     defined(__linux__)
-
 int uv__nonblock_ioctl(int fd, int set) {
   int r;
 
@@ -494,8 +493,7 @@ int uv__cloexec_ioctl(int fd, int set) {
 
   return 0;
 }
-
-#else
+#endif
 
 int uv__nonblock_fcntl(int fd, int set) {
   int flags;
@@ -528,12 +526,10 @@ int uv__nonblock_fcntl(int fd, int set) {
 }
 
 
-#if defined(__NUTTX__)
-int uv__cloexec(int fd, int set) {
-  return 0;
-}
-#else
 int uv__cloexec_fcntl(int fd, int set) {
+#if defined(__NUTTX__)
+  return 0;
+#endif
   int flags;
   int r;
 
@@ -562,8 +558,6 @@ int uv__cloexec_fcntl(int fd, int set) {
 
   return 0;
 }
-#endif
-#endif
 
 
 #if defined(__NUTTX__)

--- a/src/unix/internal.h
+++ b/src/unix/internal.h
@@ -181,8 +181,6 @@ struct uv__stream_queued_fds_s {
     defined(__linux__)
 #define uv__cloexec uv__cloexec_ioctl
 #define uv__nonblock uv__nonblock_ioctl
-#elif defined(__NUTTX__) /* No ioctl in nuttx */
-#define uv__nonblock uv__nonblock_fcntl
 #else
 #define uv__cloexec uv__cloexec_fcntl
 #define uv__nonblock uv__nonblock_fcntl

--- a/src/unix/linux-core.c
+++ b/src/unix/linux-core.c
@@ -154,6 +154,26 @@ void uv__platform_invalidate_fd(uv_loop_t* loop, int fd) {
 }
 
 
+int uv__io_check_fd(uv_loop_t* loop, int fd) {
+  struct uv__epoll_event e;
+  int rc;
+
+  e.events = POLLIN;
+  e.data = -1;
+
+  rc = 0;
+  if (uv__epoll_ctl(loop->backend_fd, UV__EPOLL_CTL_ADD, fd, &e))
+    if (errno != EEXIST)
+      rc = -errno;
+
+  if (rc == 0)
+    if (uv__epoll_ctl(loop->backend_fd, UV__EPOLL_CTL_DEL, fd, &e))
+      abort();
+
+  return rc;
+}
+
+
 void uv__io_poll(uv_loop_t* loop, int timeout) {
   /* A bug in kernels < 2.6.37 makes timeouts larger than ~30 minutes
    * effectively infinite on 32 bits architectures.  To avoid blocking


### PR DESCRIPTION
x86_64 linux requires uv__nonblock_fcntl also, not only
uv__nonblock_ioctl.

libtuv-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com