### PR TITLE
Armhf architecture files added from Raspbian Jessie

### DIFF
--- a/cmake/config/config_armhf-linux.cmake
+++ b/cmake/config/config_armhf-linux.cmake
@@ -1,0 +1,20 @@
+# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR armhf)
+
+SET(CMAKE_C_COMPILER   gcc)

--- a/cmake/option/option_armhf-linux.cmake
+++ b/cmake/option/option_armhf-linux.cmake
@@ -1,0 +1,31 @@
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# linux common
+include("cmake/option/option_unix_common.cmake")
+include("cmake/option/option_linux_common.cmake")
+
+# arm-linux specific
+if(DEFINED TARGET_BOARD)
+  if(${TARGET_BOARD} STREQUAL "rpi2")
+    # rpi2 specific
+    set(FLAGS_COMMON
+          ${FLAGS_COMMON}
+          )
+  else()
+    message(FATAL_ERROR "TARGET_BOARD=`${TARGET_BOARD}` is unknown to make")
+  endif()
+else()
+  message(FATAL_ERROR "TARGET_BOARD is undefined")
+endif()


### PR DESCRIPTION
Please see issue https://github.com/Samsung/iotjs/issues/601

This commit contains temporary changes for successful build with
Raspbian Jessie used in Noobs 1.9.x.

The compilation was tested with IoT.js build scripts:
https://github.com/Samsung/iotjs/

Call in iotjs folder:
./tools/build.py  --target-board=rpi2 --target-arch=armhf \
--no-parallel-build

The no-parallel-build flags is mandatory to prevent RAM
depletion by many concurrent executions of gcc.