### PR TITLE
Armhf architecture files added from Raspbian Jessie - second try

### DIFF
--- a/cmake/config/config_armhf-linux.cmake
+++ b/cmake/config/config_armhf-linux.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright 2017 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/config/config_armhf-linux.cmake
+++ b/cmake/config/config_armhf-linux.cmake
@@ -1,0 +1,30 @@
+# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR armhf)
+
+EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
+
+if (${ARCHITECTURE} STREQUAL "x86_64" OR  ${ARCHITECTURE} STREQUAL "i686")
+  set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+endif()
+
+if (${ARCHITECTURE} STREQUAL "arm???")
+  set(CMAKE_C_COMPILER gcc)
+endif()
+
+

--- a/cmake/option/option_armhf-linux.cmake
+++ b/cmake/option/option_armhf-linux.cmake
@@ -1,0 +1,31 @@
+# Copyright 2015 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# linux common
+include("cmake/option/option_unix_common.cmake")
+include("cmake/option/option_linux_common.cmake")
+
+# arm-linux specific
+if(DEFINED TARGET_BOARD)
+  if(${TARGET_BOARD} STREQUAL "rpi2")
+    # rpi2 specific
+    set(FLAGS_COMMON
+          ${FLAGS_COMMON}
+          )
+  else()
+    message(FATAL_ERROR "TARGET_BOARD=`${TARGET_BOARD}` is unknown to make")
+  endif()
+else()
+  message(FATAL_ERROR "TARGET_BOARD is undefined")
+endif()

--- a/cmake/option/option_armhf-linux.cmake
+++ b/cmake/option/option_armhf-linux.cmake
@@ -22,6 +22,7 @@ if(DEFINED TARGET_BOARD)
     # rpi2 specific
     set(FLAGS_COMMON
           ${FLAGS_COMMON}
+              -lrt
           )
   else()
     message(FATAL_ERROR "TARGET_BOARD=`${TARGET_BOARD}` is unknown to make")

--- a/cmake/option/option_armhf-linux.cmake
+++ b/cmake/option/option_armhf-linux.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright 2017 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,10 +20,7 @@ include("cmake/option/option_linux_common.cmake")
 if(DEFINED TARGET_BOARD)
   if(${TARGET_BOARD} STREQUAL "rpi2")
     # rpi2 specific
-    set(FLAGS_COMMON
-          ${FLAGS_COMMON}
-              -lrt
-          )
+    set(FLAGS_COMMON ${FLAGS_COMMON} -lrt)
   else()
     message(FATAL_ERROR "TARGET_BOARD=`${TARGET_BOARD}` is unknown to make")
   endif()


### PR DESCRIPTION
Please see pull request [61](https://github.com/Samsung/libtuv/pull/61) for reference.

The Ubuntu cross compilation  gcc-arm-linux-gnueabihf fails to compile working libtuv for Rasperry Pi 2 Raspbian Jessie.
    
Ubuntu Precise fail to compile libtuv because it uses older cmake. Ubuntu Trusty and Xenial compile libtuv but executable generates SEGFAULT during run. The tools fail to compile hello world also.
    
The only working with Raspbian cross-compiler for Ubuntu is stored by RaspberryPi team at [GITHUB](https://github.com/raspberrypi/tools).
    
It is in folder for 64-bit Ubuntu:
    
        tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64
    
When you reconfigure your machine to use this compiler:
    
        $export PATH="tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin:$PATH"
    
You can compile it with makefile:
    
        TUV_PLATFORM=armhf-linux TUV_BOARD=rpi2 make
    
The GCC linaro toolchain fails to enable librt by default so it was necessary to add flag -ltr.
