### PR TITLE
Armhf architecture files added from Raspbian Jessie - yet again

### DIFF
--- a/cmake/config/config_armhf-linux.cmake
+++ b/cmake/config/config_armhf-linux.cmake
@@ -1,0 +1,18 @@
+# Copyright 2017 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+SET(CMAKE_C_COMPILER  arm-linux-gnueabihf-gcc)
+

--- a/cmake/option/option_armhf-linux.cmake
+++ b/cmake/option/option_armhf-linux.cmake
@@ -1,0 +1,20 @@
+# Copyright 2017 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# linux common
+include("cmake/option/option_unix_common.cmake")
+include("cmake/option/option_linux_common.cmake")
+
+set(FLAGS_COMMON ${FLAGS_COMMON} -lrt)
+


### PR DESCRIPTION
Please see pull request [61](https://github.com/Samsung/libtuv/pull/61) for reference.

The Ubuntu cross compilation  gcc-arm-linux-gnueabihf fails to compile working libtuv for Rasperry Pi 2 Raspbian Jessie.
    
Ubuntu Precise fail to compile libtuv because it uses older cmake. Ubuntu Trusty and Xenial compile libtuv but executable generates SEGFAULT during run. The tools fail to compile hello world also.
    
The only working with Raspbian cross-compiler for Ubuntu is stored by RaspberryPi team at [GITHUB](https://github.com/raspberrypi/tools).
    
It is in folder for 64-bit Ubuntu:
    
        tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64
    
When you reconfigure your machine to use this compiler:
    
        $export PATH="tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin:$PATH"
    
You can compile it with makefile:
    
        TUV_PLATFORM=armhf-linux TUV_BOARD=rpi2 make
    
The GCC linaro toolchain fails to enable librt by default so it was necessary to add flag -ltr.
