### PR TITLE
Artik tizen

### DIFF
--- a/cmake/config/config_noarch-linux.cmake
+++ b/cmake/config/config_noarch-linux.cmake
@@ -1,0 +1,21 @@
+# Copyright 2017 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is used for compilation without any compiler flags or 
+# cross compilation options. Default make always checks for CPU
+# and operating system and tries to find config_cpu_os.cmake.
+#
+# This file you can include using flags:
+# $  TUV_PLATFORM=noarch-linux make
+

--- a/cmake/option/option_noarch-linux.cmake
+++ b/cmake/option/option_noarch-linux.cmake
@@ -1,0 +1,18 @@
+# Copyright 2017 Samsung Electronics Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# linux common
+include("cmake/option/option_unix_common.cmake")
+include("cmake/option/option_linux_common.cmake")
+


### PR DESCRIPTION
Armv7l architecture introduced with Tizen OS
    
Tizen OS is Linux distribution for embedded devices so Linux operating system is used for most of internal Makefile flags but both _tizen_ and _artik_ was introduced as new OS and board at highest makefile level for further development.
    
The _libtuv_ was tested with gbs 0.24.4: https://goo.gl/lZ3q7p

GBS was configured with _Tizen Common 3.0 Artik_ build:
http://download.tizen.org/snapshots/tizen/common_artik

The compilation:
```
TUV_PLATFORM=armv7l-tizen TUV_BOARD=artik make
```
    
The _tuvtester_ was executed at Artik 10 with 100% pass rate:
https://www.artik.io/modules/artik-1020/
