### PR TITLE
Report error if TARGET_PLATFORM was not defined

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -32,6 +32,10 @@ endif()
 
 # path for platform depends files, use full name for default
 # (e.g, i686-linux)
+if (NOT DEFINED TARGET_PLATFORM)
+  message(FATAL_ERROR "TARGET_PLATFORM was not specified! (e.g., arm-linux)")
+endif()
+
 set(TUV_PLATFORM_PATH ${TARGET_PLATFORM})
 include("cmake/option/option_${TARGET_PLATFORM}.cmake")
 


### PR DESCRIPTION
When calling the cmake for the project if
the TARGET_PLATFORM definition is not set only a cryptic
file not found error is displayed for the user.

By checking the TARGET_PLATFORM cmake definition
we can avoid the file not found error and display
a more descriptive reason why the cmake call failed.