### PR TITLE
Remove remnants of C++

### DIFF
--- a/cmake/option/option_arm-nuttx.cmake
+++ b/cmake/option/option_arm-nuttx.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright 2015-2017 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -55,7 +55,6 @@ endif()
 set(TARGET_INC
       ${TARGET_INC}
       "${TARGET_SYSTEMROOT}/include"
-      "${TARGET_SYSTEMROOT}/include/cxx"
       )
 
 # build tester as library

--- a/cmake/option/option_raw_common.cmake
+++ b/cmake/option/option_raw_common.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright 2015-2017 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,16 +17,8 @@ set(FLAGS_COMMON
       "-D__TUV_RAW__"
       )
 
-set(FLAGS_CXXONLY
-      "-fpermissive"
-      "-fno-exceptions"
-      "-fno-rtti"
-      )
-
 set(CMAKE_C_FLAGS_DEBUG     "-O0 -g -DDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG   "-O0 -g -DDEBUG")
 set(CMAKE_C_FLAGS_RELEASE   "-O2 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 
 # raw common source files
 set(RAW_PATH "${SOURCE_ROOT}/raw")

--- a/cmake/option/option_unix_common.cmake
+++ b/cmake/option/option_unix_common.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright 2015-2017 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,6 @@
 
 set(FLAGS_COMMON
       "-fno-builtin"
-      )
-
-set(FLAGS_CXXONLY
-      "-fpermissive"
-      "-fno-exceptions"
-      "-fno-rtti"
       )
 
 set(CMAKE_C_FLAGS_DEBUG     "-O0 -g -DDEBUG")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright 2015-2017 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,11 +46,6 @@ endif()
 
 foreach(FLAG ${FLAGS_COMMON})
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAG}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
-endforeach()
-
-foreach(FLAG ${FLAGS_CXXONLY})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAG}")
 endforeach()
 
 # generate configure file

--- a/tools/apt-get-install-arm.sh
+++ b/tools/apt-get-install-arm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright 2016-2017 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 sudo apt-get update -q
 sudo apt-get install -q -y \
-    g++-arm-linux-gnueabihf libc6-dev-armhf-cross
+    gcc-arm-linux-gnueabihf libc6-dev-armhf-cross

--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright 2016-2017 Samsung Electronics Co., Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 sudo apt-get update -q
 sudo apt-get install -q -y \
-    cmake g++
+    cmake gcc


### PR DESCRIPTION
The project is clean C, no need for maintaining any unused C++
specifics.

libtuv-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu