### PR TITLE
Workaround for incomplete POSIX tizenrt includes

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -47,12 +47,12 @@
 #if !defined(__NUTTX__) && \
     !defined(__TIZENRT__) /* No netinet/tcp.h */
 #include <netinet/tcp.h>
+#include <pwd.h>
 #endif
 #include <arpa/inet.h>
 #include <netdb.h>
 
 #include <termios.h>
-#include <pwd.h>
 
 #include <semaphore.h>
 #include <pthread.h>
@@ -61,39 +61,39 @@
 #include "uv-threadpool.h"
 
 #if defined(__linux__)
-# include "uv-linux.h"
+  #include "uv-linux.h"
 #elif defined(_AIX)
-# include "uv-aix.h"
+  #include "uv-aix.h"
 #elif defined(__sun)
-# include "uv-sunos.h"
+  #include "uv-sunos.h"
 #elif defined(__APPLE__)
-# include "uv-darwin.h"
+  #include "uv-darwin.h"
 #elif defined(__DragonFly__)       || \
       defined(__FreeBSD__)         || \
       defined(__FreeBSD_kernel__)  || \
       defined(__OpenBSD__)         || \
       defined(__NetBSD__)
-# include "uv-bsd.h"
+  #include "uv-bsd.h"
 #elif defined(__NUTTX__)
-# include "uv-nuttx.h"
+  #include "uv-nuttx.h"
 #elif defined(__TIZENRT__)
-# include "uv-tizenrt.h"
+  #include "uv-tizenrt.h"
 #endif
 
 #ifndef PTHREAD_BARRIER_SERIAL_THREAD
-# include "pthread-barrier.h"
+  #include "pthread-barrier.h"
 #endif
 
 #ifndef NI_MAXHOST
-# define NI_MAXHOST 1025
+  #define NI_MAXHOST 1025
 #endif
 
 #ifndef NI_MAXSERV
-# define NI_MAXSERV 32
+  #define NI_MAXSERV 32
 #endif
 
 #ifndef UV_IO_PRIVATE_PLATFORM_FIELDS
-# define UV_IO_PRIVATE_PLATFORM_FIELDS /* empty */
+  #define UV_IO_PRIVATE_PLATFORM_FIELDS /* empty */
 #endif
 
 struct uv__io_s;

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -53,47 +53,47 @@
 #include <arpa/inet.h>
 #include <limits.h> /* INT_MAX, PATH_MAX, IOV_MAX */
 #if !defined(__TIZENRT__)
-# include <sys/uio.h> /* writev */
+  #include <sys/uio.h> /* writev */
+  #include <pwd.h>
 #endif
-#include <pwd.h>
 
 #ifdef __sun
-# include <sys/filio.h>
-# include <sys/types.h>
-# include <sys/wait.h>
+  #include <sys/filio.h>
+  #include <sys/types.h>
+  #include <sys/wait.h>
 #endif
 
 #ifdef __APPLE__
-# include <mach-o/dyld.h> /* _NSGetExecutablePath */
-# include <sys/filio.h>
-# if defined(O_CLOEXEC)
-#  define UV__O_CLOEXEC O_CLOEXEC
-# endif
+  #include <mach-o/dyld.h> /* _NSGetExecutablePath */
+  #include <sys/filio.h>
+  #if defined(O_CLOEXEC)
+    #define UV__O_CLOEXEC O_CLOEXEC
+  #endif
 #endif
 
 #if defined(__DragonFly__)      || \
     defined(__FreeBSD__)        || \
     defined(__FreeBSD_kernel__)
-# include <sys/sysctl.h>
-# include <sys/filio.h>
-# include <sys/wait.h>
-# define UV__O_CLOEXEC O_CLOEXEC
-# if defined(__FreeBSD__) && __FreeBSD__ >= 10
-#  define uv__accept4 accept4
-#  define UV__SOCK_NONBLOCK SOCK_NONBLOCK
-#  define UV__SOCK_CLOEXEC  SOCK_CLOEXEC
-# endif
-# if !defined(F_DUP2FD_CLOEXEC) && defined(_F_DUP2FD_CLOEXEC)
-#  define F_DUP2FD_CLOEXEC  _F_DUP2FD_CLOEXEC
-# endif
+  #include <sys/sysctl.h>
+  #include <sys/filio.h>
+  #include <sys/wait.h>
+  #define UV__O_CLOEXEC O_CLOEXEC
+  #if defined(__FreeBSD__) && __FreeBSD__ >= 10
+    #define uv__accept4 accept4
+    #define UV__SOCK_NONBLOCK SOCK_NONBLOCK
+    #define UV__SOCK_CLOEXEC  SOCK_CLOEXEC
+  #endif
+  #if !defined(F_DUP2FD_CLOEXEC) && defined(_F_DUP2FD_CLOEXEC)
+    #define F_DUP2FD_CLOEXEC  _F_DUP2FD_CLOEXEC
+  #endif
 #endif
 
 #if defined(__ANDROID_API__) && __ANDROID_API__ < 21
-# include <dlfcn.h>  /* for dlsym */
+  #include <dlfcn.h>  /* for dlsym */
 #endif
 
 #if defined(__MVS__)
-#include <sys/ioctl.h>
+  #include <sys/ioctl.h>
 #endif
 
 static int uv__run_pending(uv_loop_t* loop);

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -55,12 +55,12 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #if !defined(__TIZENRT__)
-# include <sys/uio.h> /* writev */
+  #include <sys/uio.h> /* writev */
+  #include <utime.h>
 #endif
 #include <pthread.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <utime.h>
 #include <poll.h>
 
 #if defined(__DragonFly__)        ||                                      \
@@ -68,13 +68,13 @@
     defined(__FreeBSD_kernel_)    ||                                      \
     defined(__OpenBSD__)          ||                                      \
     defined(__NetBSD__)
-# define HAVE_PREADV 1
+  #define HAVE_PREADV 1
 #else
-# define HAVE_PREADV 0
+  #define HAVE_PREADV 0
 #endif
 
 #if defined(__linux__) || defined(__sun)
-# include <sys/sendfile.h>
+  #include <sys/sendfile.h>
 #endif
 
 #define INIT(subtype)                                                         \


### PR DESCRIPTION
Workaround for incomplete POSIX tizenrt includes (utime.h, pwd.h)
libtuv-DCO-1.0-Signed-off-by: Tomasz Wozniak t.wozniak@samsung.com