### PR TITLE
Only define ENOTSUP if needed

### DIFF
--- a/include/uv-nuttx.h
+++ b/include/uv-nuttx.h
@@ -57,7 +57,10 @@
 
 //---------------------------------------------------------------------------
 // @20161130-sanggyu: nuttx does not provide ENOTSUP.
+// @20170407-galpeter: nuttx started to provide ENOTSUP.
+#ifndef ENOTSUP
 #define ENOTSUP       EOPNOTSUPP
+#endif
 
 // @20171130-sanggyu:
 // Not defined macro. Copied from x86-64 linux system header


### PR DESCRIPTION
In nuttx the ENOTSUP was not defined previously. However
newer nuttx version provieds this macro. We need a guard to avoid
macro redefinition.

libtuv-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com