### PR TITLE
tizen: make compiler overridable for GBS

### DIFF
--- a/cmake/config/config_arm-tizen.cmake
+++ b/cmake/config/config_arm-tizen.cmake
@@ -17,4 +17,6 @@ include(CMakeForceCompiler)
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-SET(CMAKE_C_COMPILER   arm-linux-gnueabi-gcc)
+if(NOT DEFINED CMAKE_C_COMPILER)
+  set(CMAKE_C_COMPILER arm-linux-gnueabi-gcc)
+endif()


### PR DESCRIPTION
There is no arm-linux-gnueabi-gcc in Tizen sysroot,
I assume it is used for cross compilation.

To build using GBS (git-build-system),
this variable can be used to use system compiler "gcc" this way:

  cmake -DCMAKE_C_COMPILER=gcc .

Observed issue on Tizen:4.0:Unified (armv7l) was:

  -- Check for working C compiler: arm-linux-gnueabi-gcc
  CMake Error: your C compiler: "arm-linux-gnueabi-gcc" was not found.
  Please set CMAKE_C_COMPILER to a valid compiler path or name.

libtuv-DCO-1.0-Signed-off-by: Philippe Coval philippe.coval@osg.samsung.com