### PR TITLE
Use SO_REUSEADDR instead of SO_REUSEPORT on TizenRT

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -328,7 +328,7 @@ static void uv__udp_sendmsg(uv_udp_t* handle) {
 static int uv__set_reuse(int fd) {
   int yes;
 
-#if defined(SO_REUSEPORT) && !defined(__linux__)
+#if defined(SO_REUSEPORT) && !defined(__linux__) && !defined(__TIZENRT__)
   yes = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &yes, sizeof(yes)))
     return -errno;


### PR DESCRIPTION
TizenRT uses lwip for IP stack.
It provides SO_REUSEADDR for port reuse.