### PR TITLE
Fix headers for TizenRT

### DIFF
--- a/include/uv-unix.h
+++ b/include/uv-unix.h
@@ -52,7 +52,9 @@
 #include <netdb.h>
 
 #include <termios.h>
+#if !defined(__NUTTX__) && !defined(__TIZENRT__)
 #include <pwd.h>
+#endif
 
 #include <semaphore.h>
 #include <pthread.h>

--- a/src/unix/core.c
+++ b/src/unix/core.c
@@ -54,8 +54,8 @@
 #include <limits.h> /* INT_MAX, PATH_MAX, IOV_MAX */
 #if !defined(__TIZENRT__)
 # include <sys/uio.h> /* writev */
+# include <pwd.h>
 #endif
-#include <pwd.h>
 
 #ifdef __sun
 # include <sys/filio.h>

--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -56,11 +56,11 @@
 #include <sys/time.h>
 #if !defined(__TIZENRT__)
 # include <sys/uio.h> /* writev */
+# include <utime.h>
 #endif
 #include <pthread.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <utime.h>
 #include <poll.h>
 
 #if defined(__DragonFly__)        ||                                      \


### PR DESCRIPTION
This system doesn't provide utime.h and pwd.h headers.

Signed-off-by: Jaroslaw Pelczar <j.pelczar@samsung.com>