### PR TITLE
Fix an error, causing stderr to close

### DIFF
--- a/src/tuv_debuglog.c
+++ b/src/tuv_debuglog.c
@@ -61,7 +61,7 @@ void InitDebugSettings() {
 
 void ReleaseDebugSettings() {
 #ifdef ENABLE_DEBUG_LOG
-  if (tuv_log_stream != stderr || tuv_log_stream != stdout) {
+  if (tuv_log_stream != stderr && tuv_log_stream != stdout) {
     fclose(tuv_log_stream);
   }
   // some embed systems(ex, nuttx) may need this


### PR DESCRIPTION
There is a problem in the logic of the if check, causing it to always execute.

libtuv-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu