### PR TITLE
Fix uv__to_stat function on Nuttx with newer gcc

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -578,8 +578,8 @@ static void uv__to_stat(struct stat* src, uv_stat_t* dst) {
   dst->st_birthtim.tv_nsec = src->st_ctimensec;
   dst->st_flags = 0;
   dst->st_gen = 0;
-#elif !defined(_AIX) && (       \
-    defined(_GNU_SOURCE)     || \
+#elif !defined(_AIX) && !defined(__NUTTX__) && \
+    (defined(_GNU_SOURCE)    || \
     defined(_BSD_SOURCE)     || \
     defined(_SVID_SOURCE)    || \
     defined(_XOPEN_SOURCE)   || \


### PR DESCRIPTION
With a newer arm gcc (5.0+) the _DEFAULT_SOURCE macro
gets defined when the unix/fs.c file is built thus
trying to access a set of stat struct members which
are not defined on Nuttx.

By adding an extra check to see if the build is for
Nuttx we can correctly select the stat conversion
code path.

libtuv-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com