### PR TITLE
Remove CMakeForceCompiler

### DIFF
--- a/cmake/config/config_arm-linux.cmake
+++ b/cmake/config/config_arm-linux.cmake
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-SET(CMAKE_C_COMPILER   arm-linux-gnueabihf-gcc)
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)

--- a/cmake/config/config_arm-mbed.cmake
+++ b/cmake/config/config_arm-mbed.cmake
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME mbed)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-SET(CMAKE_C_COMPILER   arm-none-eabi-g++)
-
-# need to force compiler,
-# else it'll try to check and exit with 'unedefined _exit()
-CMAKE_FORCE_C_COMPILER(${CMAKE_C_COMPILER} GNU)
+set(CMAKE_C_COMPILER arm-none-eabi-g++)
+set(CMAKE_C_COMPILER_WORKS TRUE)

--- a/cmake/config/config_arm-nuttx.cmake
+++ b/cmake/config/config_arm-nuttx.cmake
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME nuttx)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-SET(CMAKE_C_COMPILER   arm-none-eabi-gcc)
-
-# need to force compiler,
-# else it'll try to check and exit with 'unedefined _exit()
-CMAKE_FORCE_C_COMPILER(${CMAKE_C_COMPILER} GNU)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_C_COMPILER_WORKS TRUE)

--- a/cmake/config/config_arm-tizen.cmake
+++ b/cmake/config/config_arm-tizen.cmake
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 

--- a/cmake/config/config_arm-tizenrt.cmake
+++ b/cmake/config/config_arm-tizenrt.cmake
@@ -12,13 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME tizenrt)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-SET(CMAKE_C_COMPILER   arm-none-eabi-gcc)
-
-# need to force compiler,
-# else it'll try to check and exit with 'unedefined _exit()
-CMAKE_FORCE_C_COMPILER(${CMAKE_C_COMPILER} GNU)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_C_COMPILER_WORKS TRUE)

--- a/cmake/config/config_armhf-linux.cmake
+++ b/cmake/config/config_armhf-linux.cmake
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
-SET(CMAKE_C_COMPILER  arm-linux-gnueabihf-gcc)
-
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)

--- a/cmake/config/config_i686-linux.cmake
+++ b/cmake/config/config_i686-linux.cmake
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR i686)

--- a/cmake/config/config_mips-openwrt.cmake
+++ b/cmake/config/config_mips-openwrt.cmake
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Openwrt)
 set(CMAKE_SYSTEM_PROCESSOR mips)
 
-SET(CMAKE_C_COMPILER   mipsel-openwrt-linux-gcc)
+set(CMAKE_C_COMPILER mipsel-openwrt-linux-gcc)

--- a/cmake/config/config_mipsel-linux.cmake
+++ b/cmake/config/config_mipsel-linux.cmake
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR mipsel)
 
-SET(CMAKE_C_COMPILER   mipsel-linux-gcc)
+set(CMAKE_C_COMPILER mipsel-linux-gcc)

--- a/cmake/config/config_x86_64-darwin.cmake
+++ b/cmake/config/config_x86_64-darwin.cmake
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Darwin)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)

--- a/cmake/config/config_x86_64-linux.cmake
+++ b/cmake/config/config_x86_64-linux.cmake
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(CMakeForceCompiler)
-
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)


### PR DESCRIPTION
CMakeForceCompiler is deprecated.

libtuv-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com