### PR TITLE
Remove unnecessary lib copy on TizenRT

### DIFF
--- a/cmake/option/option_arm-tizenrt.cmake
+++ b/cmake/option/option_arm-tizenrt.cmake
@@ -52,6 +52,3 @@ set(TARGET_INC
 # build tester as library
 set(BUILD_TEST_LIB "yes")
 unset(BUILD_TEST_LIB CACHE)
-
-# set copy libs to ${TARGET_SYSTEMROOT}/lib
-set(COPY_TARGET_LIB "${TARGET_SYSTEMROOT}/lib")


### PR DESCRIPTION
Remove unnecessary lib(os/lib) copy on TizenRT

libtuv-DCO-1.0-Signed-off-by: Haesik, Jun haesik.jun@samsung.com