### PR TITLE
Don't copy libtuv.a to NuttX lib directory

### DIFF
--- a/cmake/option/option_arm-tizenrt.cmake
+++ b/cmake/option/option_arm-tizenrt.cmake
@@ -52,6 +52,3 @@ set(TARGET_INC
 # build tester as library
 set(BUILD_TEST_LIB "yes")
 unset(BUILD_TEST_LIB CACHE)
-
-# set copy libs to ${TARGET_SYSTEMROOT}/lib
-set(COPY_TARGET_LIB "${TARGET_SYSTEMROOT}/lib")


### PR DESCRIPTION
Our policy for copying libtuv.a is changed for consistency.
In IoT.js, dep libraries have different policy on copying the output.
For example, libtuv is copied to target OS's library folders for NuttX,
but not copied for TizenRT. libhttpparser is not copied at all for all
platforms.
libtuv will not copy the final output library to other directories.
Each application will gather the dep libraries to target OS's lib
folder.

libtuv-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com