### PR TITLE
Update OpenWrt CMake files

### DIFF
--- a/cmake/config/config_mips-openwrt.cmake
+++ b/cmake/config/config_mips-openwrt.cmake
@@ -15,4 +15,4 @@
 set(CMAKE_SYSTEM_NAME Openwrt)
 set(CMAKE_SYSTEM_PROCESSOR mips)
 
-set(CMAKE_C_COMPILER mipsel-openwrt-linux-gcc)
+set(CMAKE_C_COMPILER mips-openwrt-linux-gcc)

--- a/cmake/option/option_mips-openwrt.cmake
+++ b/cmake/option/option_mips-openwrt.cmake
@@ -14,28 +14,4 @@
 
 # linux common
 include("cmake/option/option_unix_common.cmake")
-
-set(TUV_PLATFORM_PATH "linux")
-set(BUILDTESTER "no")
-set(BUILDAPIEMULTESTER "no")
-
-# linux specific source files
-set(LINUX_PATH "${SOURCE_ROOT}/${TUV_PLATFORM_PATH}")
-
-set(PLATFORM_SRCFILES ${PLATFORM_SRCFILES}
-                      "${LINUX_PATH}/uv_linux.c"
-                      "${LINUX_PATH}/uv_linux_loop.c"
-                      "${LINUX_PATH}/uv_linux_clock.c"
-                      "${LINUX_PATH}/uv_linux_io.c"
-                      "${LINUX_PATH}/uv_linux_syscall.c"
-                      "${LINUX_PATH}/uv_linux_thread.c"
-                      )
-
-set(PLATFORM_TESTFILES "${TEST_ROOT}/runner_linux.c"
-                       )
-
-set(TUV_LINK_LIBS "pthread")
-
-# mips-linux specific
-if(DEFINED TARGET_BOARD)
-endif()
+include("cmake/option/option_linux_common.cmake")


### PR DESCRIPTION
Switch to use 'mips-' compiler and not
'mipsel-' as the processor was set to 'mips'.

Updated the options cmake for mips-openwrt to
use the common linux/unix options.