### PR TITLE
Checks whether the _SC_CLK_TCK and CLOCK_MONOTONIC has been defined earlier

### DIFF
--- a/include/uv-nuttx.h
+++ b/include/uv-nuttx.h
@@ -70,6 +70,14 @@
 #define SIGPROF       27
 #define TCP_NODELAY   1
 
+#ifndef _SC_CLK_TCK
+#define _SC_CLK_TCK 0x0006
+#endif
+
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 1
+#endif
+
 //-----------------------------------------------------------------------------
 // date time extension
 // uint64_t uv__time_precise();


### PR DESCRIPTION
I've removed these defines earlier in https://github.com/Samsung/libtuv/pull/113, which was a hot fix. It worked with my local configuration but not in docker environment.
I have put these defines back, but within #ifndef checks to prevent redefinition errors.