### PR TITLE
Fix Sleep call in Windows

### DIFF
--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -492,7 +492,7 @@ int uv_loop_close(uv_loop_t* loop) {
 /* Pause the calling thread for a number of milliseconds. */
 void uv_sleep(int msec) {
 #ifdef _WIN32
-  Sleep(msec * 1000);
+  Sleep(msec);
 #else
   usleep(msec * 1000);
 #endif


### PR DESCRIPTION
On Windows the Sleep call already expects msecs
there is no need to multiply it with 1000.