### PR TITLE
tizenrt: Skip IPv6 code if feature disabled

### DIFF
--- a/src/unix/udp.c
+++ b/src/unix/udp.c
@@ -437,6 +437,7 @@ static int uv__udp_maybe_deferred_bind(uv_udp_t* handle,
     addrlen = sizeof *addr;
     break;
   }
+#if !defined(__TIZENRT__) || defined(CONFIG_NET_IPv6)
   case AF_INET6:
   {
     struct sockaddr_in6* addr = (void*)&taddr;
@@ -446,6 +447,7 @@ static int uv__udp_maybe_deferred_bind(uv_udp_t* handle,
     addrlen = sizeof *addr;
     break;
   }
+#endif
   default:
     assert(0 && "unsupported address family");
     abort();


### PR DESCRIPTION
Observed issue while building IoT.js (master)
on TizenRT (master) with artik055s/nettest config:

    arm-none-eabi-ld (...) \
    -o ".../build/output/bin/tinyara" (...) \
    .../build/output/bin/tinyara.map \
    .../build/output/libraries/libtuv.a(udp.c.obj): \
    In function `uv__udp_maybe_deferred_bind': \
    TizenRT/external/iotjs/deps/libtuv/src/unix/udp.c:445: \
    undefined reference to `in6addr_any'

Note TizenRT's artik055s/nettest image hasn't CONFIG_NET_IPv6 defined,
while artik053 has it, both should be aligned.

libtuv-DCO-1.0-Signed-off-by: Philippe Coval <p.coval@samsung.com>