### PR TITLE
Fix SVACE defect in IoT.js (fs.scandir)

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -407,6 +407,12 @@ static ssize_t uv__fs_scandir(uv_fs_t* req) {
       cnt++;
   }
 
+  if (cnt > 0 && dents == NULL) {
+      closedir(dir);
+      cnt = -1;
+      goto error;
+  }
+
   /* Allcoate memory for the directory entries. */
   dents = (uv__dirent_t**) malloc(sizeof (uv__dirent_t*) * cnt);
 


### PR DESCRIPTION
[Philippe Coval]

While updating IoT.js in Tizen:RT,
I noticed this downstream patch,
it stills applies to current version of IoT.js
so I am forwarding it upstream.

To help crosstracking a Change-Id and some references add.

Author: Sanggyu Lee <sg5.lee@samsung.com>
Origin: https://github.com/Samsung/TizenRT/commit/51262d262dfbace812d858aaed3d8f29df44c5e7
Change-Id: I16cbca383d4e5a7a8cc36eace93999a622f19adc
libtuv-DCO-1.0-Signed-off-by: Philippe Coval p.coval@samsung.com