### PR TITLE
Fix fs.scandir (introduced by #122)

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -407,13 +407,7 @@ static ssize_t uv__fs_scandir(uv_fs_t* req) {
       cnt++;
   }
 
-  if (cnt > 0 && dents == NULL) {
-      closedir(dir);
-      cnt = -1;
-      goto error;
-  }
-
-  /* Allcoate memory for the directory entries. */
+  /* Allocate memory for the directory entries. */
   dents = (uv__dirent_t**) malloc(sizeof (uv__dirent_t*) * cnt);
 
   if (cnt > 0 && dents == NULL) {


### PR DESCRIPTION
The check should be after the allocation, where it is.
It was misplaced and also duplicated the existing one.