### PR TITLE
Move strdup into the uv__strdup function.

### DIFF
--- a/src/unix/fs.c
+++ b/src/unix/fs.c
@@ -98,7 +98,7 @@
     if (cb == NULL) {                                                         \
       req->path = path;                                                       \
     } else {                                                                  \
-      req->path = strdup(path);                                               \
+      req->path = uv__strdup(path);                                           \
       if (req->path == NULL) {                                                \
         uv__req_unregister(loop, req);                                        \
         return -ENOMEM;                                                       \

--- a/src/uv-common.c
+++ b/src/uv-common.c
@@ -67,15 +67,17 @@ static uv__allocator_t uv__allocator = {
   free,
 };
 
-#if defined(__APPLE__) || defined(_WIN32) || defined(TUV_FEATURE_PIPE)
 char* uv__strdup(const char* s) {
+#if defined(__APPLE__) || defined(_WIN32) || defined(TUV_FEATURE_PIPE)
   size_t len = strlen(s) + 1;
   char* m = uv__malloc(len);
   if (m == NULL)
     return NULL;
   return memcpy(m, s, len);
-}
+#else
+  return strdup(s);
 #endif
+}
 
 void* uv__malloc(size_t size) {
   return uv__allocator.local_malloc(size);

--- a/src/uv-common.h
+++ b/src/uv-common.h
@@ -239,9 +239,7 @@ void uv__fs_scandir_cleanup(uv_fs_t* req);
 
 /* Allocator prototypes */
 void *uv__calloc(size_t count, size_t size);
-#if defined(__APPLE__) || defined(_WIN32) || defined(TUV_FEATURE_PIPE)
 char *uv__strdup(const char* s);
-#endif
 void* uv__malloc(size_t size);
 void uv__free(void* ptr);
 void* uv__realloc(void* ptr, size_t size);

--- a/test/runner_linux.c
+++ b/test/runner_linux.c
@@ -118,7 +118,7 @@ int process_start(const char* name, const char* part, process_info_t* p,
 
   /* parent */
   p->pid = pid;
-  p->name = strdup(name);
+  p->name = uv__strdup(name);
   p->stdout_file = stdout_file;
 
   return 0;


### PR DESCRIPTION
Currently, there are `strdup` and `uv_strdup` function calls in the code. It would be nice if the direct `strdup` could be moved into the `uv_strdup` function to be similar to `uv_malloc`, `uv_realloc` functions.