### PR TITLE
Add #ifndef ENOTSUP to avoid redefinition

### DIFF
--- a/include/uv-tizenrt.h
+++ b/include/uv-tizenrt.h
@@ -56,7 +56,9 @@
 
 //---------------------------------------------------------------------------
 // TUV_CHANGES@20161130: NuttX doesn't provide ENOTSUP.
+#ifndef ENOTSUP
 #define ENOTSUP       EOPNOTSUPP
+#endif
 
 // TUV_CHANGES@20171130:
 // Not defined macros. Copied from x86-64 linux system header


### PR DESCRIPTION
If ENOTSUP is already defined, error will occur.