### PR TITLE
fix: Fix buffer overflow

### DIFF
--- a/test/test_ipc.c
+++ b/test/test_ipc.c
@@ -285,7 +285,7 @@ void spawn_helper(uv_pipe_t* channel,
   TUV_ASSERT(r == 0);
   TUV_ASSERT(channel->ipc);
 
-  exepath_size = sizeof(exepath);
+  exepath_size = sizeof(exepath) - 1;
   r = uv_exepath(exepath, &exepath_size);
   TUV_ASSERT(r == 0);
 


### PR DESCRIPTION
If we write the 1024th element on an array whose
length is 1024, it will cause buffer overflow.